### PR TITLE
rearrange edits to squid plot caption

### DIFF
--- a/doc/main-figures/main-figures.rnw
+++ b/doc/main-figures/main-figures.rnw
@@ -1268,19 +1268,17 @@ make_squid_plot(base.model,
   and expected recruitment from the spawner-recruit relationship.
   Age-0 recruitment deviations are non-zero because MCMC allows for
   sampling from the full log-normal distribution.
-  Lines represent estimated recruitment deviations for cohorts from
+  Lines represent estimated recruitment deviations for cohorts born from
   \Sexpr{min(retro_cohorts)} to \Sexpr{max(retro_cohorts)}, with cohort
-  birth year marked at the right of each color-coded line. Values are
-  estimated by models using data available only up to the start of the year in which
-  each cohort became a given age (so the last year of data is
-  cohort~birth~year~$+$~cohort~age~$-$1). For example,
-  the right-most point for the 2014 cohort shows the
-  cohort at age-8 (i.e. at the start of 2022, which represents
-  the base model and includes data to 2021). The next point
-  to the left is the 2014 cohort at age-7, calculated by
-  removing one year of data (so includes data up to 2020).}
-  % Sorry, no time to
-  % automate that right now
+  birth year marked at the right of each color-coded line.
+  For example, the right-most point for the \Sexpr{assess.yr - 8} cohort shows the
+  cohort at age eight (i.e., at the start of \Sexpr{assess.yr}, which represents
+  the base model and includes data to \Sexpr{assess.yr - 1}). The next point
+  to the left is the \Sexpr{assess.yr - 8} cohort at age seven, calculated by
+  removing one year of data (so includes data up to \Sexpr{assess.yr - 2}).
+  Thus, models are fit to data available only up to the start of the year in which
+  each cohort became a given age, i.e., data ends collection ends December 31,
+  cohort~birth~year~$+$~cohort~age~$-$1.}
 \label{fig:main-retrospective-recruitment}
 \end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
@andrew-edwards I liked the additions to the caption for the squid plot. I just thought that the example was better placed directly after the caption mentions what the lines are rather than after the math that you put in.

Feel free to change it back. That is why I did a pull request rather than a commit.