### PR TITLE
fix: Quote the path

### DIFF
--- a/bash-scripts/run-base-model.sh
+++ b/bash-scripts/run-base-model.sh
@@ -60,7 +60,7 @@ exist, bailing out." ; exit 1; }
                      num_chains = $num_chains, \
                      num_samples = $num_samples, \
                      num_warmup_samples = $num_warmup_samples,
-                     fn_exe = $ss_exe)" \
+                     fn_exe = '$ss_exe')" \
   > /dev/null 2>&1; \
   echo "Base model MCMC complete" \
 )


### PR DESCRIPTION
Use single quotes to quote the exe path like how the model path is quoted.