### PR TITLE
Adds GGally to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
   furrr,
   gfdata,
   gfplot,
+  GGally,
   ggh4x,
   ggnewscale,
   ggplot2,
@@ -76,6 +77,7 @@ Suggests:
   data.tree,
   date,
   ggpubr,
+  graphics,
   rmarkdown,
   shinystan,
   testthat

--- a/R/plot-pairs.R
+++ b/R/plot-pairs.R
@@ -150,10 +150,10 @@ plot_pairs <- function(model,
     select(matches(select_vec))
 
   # Plot for the panels in the upper triangle of the pairs plot
-  # @param data The plot data (passed from [ggAlly::ggpairs()])
+  # @param data The plot data (passed from [GGally::ggpairs()])
   # @param mapping The [ggplot2::aes()] aes mapping
-  # (passed from [ggAlly::ggpairs()])
-  # @param ... Other arguments passed from [ggAlly::ggpairs()]
+  # (passed from [GGally::ggpairs()])
+  # @param ... Other arguments passed from [GGally::ggpairs()]
   # @return
   upper_triangle <- function(data,
                              mapping,
@@ -198,9 +198,9 @@ plot_pairs <- function(model,
   }
 
   # Plot for the panels in the lower triangle of the pairs plot
-  # @param data The plot data (passed from [ggAlly::ggpairs()])
-  # @param mapping The [ggplot2::aes()] aes mapping  (passed from [ggAlly::ggpairs()])
-  # @param ... Other arguments passed from [ggAlly::ggpairs()]
+  # @param data The plot data (passed from [GGally::ggpairs()])
+  # @param mapping The [ggplot2::aes()] aes mapping  (passed from [GGally::ggpairs()])
+  # @param ... Other arguments passed from [GGally::ggpairs()]
   # @return
   lower_triangle <- function(data, mapping, ...){
 
@@ -239,9 +239,9 @@ plot_pairs <- function(model,
   }
 
   # Plot for the panels in the diagonals of the pairs plot
-  # @param data The plot data (passed from [ggAlly::ggpairs()])
-  # @param mapping The [ggplot2::aes()] aes mapping  (passed from [ggAlly::ggpairs()])
-  # @param ... Other arguments passed from [ggAlly::ggpairs()]
+  # @param data The plot data (passed from [GGally::ggpairs()])
+  # @param mapping The [ggplot2::aes()] aes mapping  (passed from [GGally::ggpairs()])
+  # @param ... Other arguments passed from [GGally::ggpairs()]
   # @return
   diagonals <- function(data, mapping, ...){
     ggally_densityDiag(data, mapping) +


### PR DESCRIPTION
This PR fixes the DESCRIPTION file because I did not have {GGally} installed and thus `devtools::load_all()` was not working for me. I am not sure @cgrandin if you actually want this in the imports because I could not see anywhere it was actually being used except in documentation but you do not always use `::` so it could be hidden somewhere. I also fixed the package name in the documentation, from `ggAlly::` to `GGally::`, please revise as needed. I did NOT run `devtools::document()` to update any of the automated files.